### PR TITLE
Fix Netlify 404 error with proper routing configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,5 +7,5 @@
 
 [[redirects]]
   from = "/*"
-  to = "/index.html"
+  to = "/200.html"
   status = 200

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -3,7 +3,7 @@ export default defineNuxtConfig({
   nitro: {
     preset: 'netlify',
     prerender: {
-      routes: ['/']
+      routes: ['/', '/about']
     }
   },
   


### PR DESCRIPTION
## Summary

- Fix 404 errors occurring on Netlify deployment after Vue 3/Nuxt 3 upgrade
- Improve static site generation configuration for proper page routing
- Update Netlify SPA fallback configuration

## Changes

### Prerendering Configuration
- Add `/about` route to `prerender.routes` in `nuxt.config.js`
- Ensure all application pages are pre-rendered for static deployment
- Maintain compatibility with Nuxt 3 static generation

### Netlify Configuration
- Update redirect fallback from `/index.html` to `/200.html`
- Align with Nuxt 3's static generation output structure
- Fix SPA routing issues on direct page access

## Root Cause

The 404 errors were caused by:
1. **Missing prerendered routes**: Only `/` was being pre-rendered, causing `/about` to return 404
2. **Incorrect SPA fallback**: Netlify was redirecting to `/index.html` which doesn't exist in Nuxt 3's output
3. **Static generation mismatch**: Configuration wasn't aligned with Nuxt 3's file structure

## Test Plan

- [x] Build succeeds without errors
- [x] Home page (`/`) loads correctly
- [x] About page (`/about`) loads without 404
- [x] Direct URL access works for all routes
- [x] Client-side navigation functions properly

## Related

This fixes deployment issues introduced in the Vue 3/Nuxt 3 upgrade PR #12.

🤖 Generated with [Claude Code](https://claude.ai/code)