### PR TITLE
Fix Netlify 404 error by updating redirect target for Nuxt 3

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,5 +7,5 @@
 
 [[redirects]]
   from = "/*"
-  to = "/200.html"
+  to = "/index.html"
   status = 200


### PR DESCRIPTION
## Summary
- Fixed Netlify 404 error by updating redirect target from `/200.html` to `/index.html` in netlify.toml
- Resolves compatibility issues after upgrading to Nuxt 3

## Test plan
- [ ] Deploy to Netlify and verify no 404 errors occur
- [ ] Test routing to all pages (/, /about)
- [ ] Verify static assets load correctly

🤖 Generated with [Claude Code](https://claude.ai/code)