### PR TITLE
Fix copyright footer positioning

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -66,4 +66,14 @@ const menuToggle = () => {
 .navbar-item h1 {
   font-size: 28px;
 }
+
+.hero.is-fullheight {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.hero-foot {
+  margin-top: auto;
+}
 </style>


### PR DESCRIPTION
## Summary
- Fixed copyright footer positioning to appear at the bottom of the page
- Added flexbox CSS rules to ensure proper layout

## Test plan
- [x] Verify copyright notice appears at bottom of homepage  
- [x] Verify copyright notice appears at bottom of about page
- [x] Test on different screen sizes

🤖 Generated with [Claude Code](https://claude.ai/code)